### PR TITLE
Update LoginActivity.java with valid links

### DIFF
--- a/FetLife/fetlife/src/main/java/com/bitlove/fetlife/view/LoginActivity.java
+++ b/FetLife/fetlife/src/main/java/com/bitlove/fetlife/view/LoginActivity.java
@@ -219,11 +219,11 @@ public class LoginActivity extends Activity {
     }
 
     public void onSignUp(View v) {
-        openLink("https://fetlife.com/signup");
+        openLink("https://fetlife.com/signup_step1");
     }
 
     public void onForgotLogin(View v) {
-        openLink("https://fetlife.com/retrieve_login_information");
+        openLink("https://fetlife.com/users/password/new");
     }
 
     private void openLink(String link) {


### PR DESCRIPTION
Fixed Login Screen URLs.

Note: Signup is disabled per @johnbaku , so you may just want to remove the signup link? I didn't make that a part of this PR because that is ultimately up to you the FL staff.

Note 2: https://fetlife.com/signup_step1 is still a valid URL, but I didn't try to make a new user to see if it still works.